### PR TITLE
Add variable to allowed to change where the sounds are located

### DIFF
--- a/loudlinks.js
+++ b/loudlinks.js
@@ -20,8 +20,8 @@ var loudlinks = (function(document) {
       oggSource = document.createElement('source'),
       eventsSet = false,
       typeReg = /{{type}}/gi, // regEx for replacing {{type}} in the URLs
-      mp3Location = 'sounds/mp3/', // mp3 sounds location
-      oggLocation = 'sounds/ogg/'; // ogg sounds location
+      mp3Location = sounds_host + 'sounds/mp3/', // mp3 sounds location
+      oggLocation = sounds_host + 'sounds/ogg/'; // ogg sounds location
 
   audioPlayer.setAttribute('preload',true); // audio element preload attribute
   mp3Source.setAttribute('type','audio/mpeg');


### PR DESCRIPTION
I was using the library in a django project and calling it in the base template. I found out that the src attributes of the audio/source elements where taking a piece of the url and they've never find out the sounds. Then, I thought that it could be a good idea to allow users to choose where to locate their sounds. So, I added a variable called "sounds_host", which has to be set before lauching the script by filling up its content with the url/path of the sounds.
