### PR TITLE
fix bubbling issue with mouseover event

### DIFF
--- a/loudlinks.js
+++ b/loudlinks.js
@@ -84,8 +84,8 @@ var loudlinks = (function(document) {
 
   // Add `hover` related event listeners
   function trackHover(element) {
-    element.addEventListener('mouseover', playAudio); // play audio on hover
-    element.addEventListener('mouseout', stopAudio); // stop audio on mouse out
+    element.addEventListener('mouseenter', playAudio); // play audio on hover
+    element.addEventListener('mouseleave', stopAudio); // stop audio on mouse out
     element.addEventListener('touchmove', stopAudio); // stop audio on touch and move
     element.addEventListener('click', stopAudio); // stop audio on click
   }


### PR DESCRIPTION
Hi there Mahdi!

This pull request aims to fix the following issue:
https://jsfiddle.net/bhzyac58/1/

When you move the cursor between the blue border and the image in the link, the sound is fired multiple times, because that's the nature of the `mouseover` event, it bubbles.

So this pull request replaces the `mouseover` and `mouseout` events in favor of [`mouseenter`](https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter) and [`mouseleave`](https://developer.mozilla.org/en-US/docs/Web/Events/mouseleave) ones.

Hope it helps!
